### PR TITLE
Fix deprecated constructors

### DIFF
--- a/src/doc/manual/example.xml
+++ b/src/doc/manual/example.xml
@@ -115,7 +115,7 @@ Atom = NUMBER
         <pre>class ArithmeticCalculator extends ArithmeticAnalyzer {
 
     protected Node exitNumber(Token node) {
-        node.addValue(new Integer(node.getImage()));
+        node.addValue(Integer.valueOf(node.getImage()));
         return node;
     }
 
@@ -134,7 +134,7 @@ Atom = NUMBER
             op = (String) values.get(1);
             result = operate(op, value1, value2);
         }
-        node.addValue(new Integer(result));
+        node.addValue(Integer.valueOf(result));
         return node;
     }
 
@@ -158,7 +158,7 @@ Atom = NUMBER
             op = (String) values.get(1);
             result = operate(op, value1, value2);
         }
-        node.addValue(new Integer(result));
+        node.addValue(Integer.valueOf(result));
         return node;
     }
 
@@ -175,7 +175,7 @@ Atom = NUMBER
         } else {
             result = getIntValue(getChildAt(node, 1), 0);
         }
-        node.addValue(new Integer(result));
+        node.addValue(Integer.valueOf(result));
         return node;
     }
 

--- a/src/java/net/percederberg/grammatica/FirstPassAnalyzer.java
+++ b/src/java/net/percederberg/grammatica/FirstPassAnalyzer.java
@@ -282,10 +282,10 @@ class FirstPassAnalyzer extends GrammarAnalyzer {
     protected Node exitTokenValue(Production node) throws ParseException {
         switch (getChildAt(node, 0).getId()) {
         case GrammarConstants.QUOTED_STRING:
-            node.addValue(new Integer(TokenPattern.STRING_TYPE));
+            node.addValue(Integer.valueOf(TokenPattern.STRING_TYPE));
             break;
         case GrammarConstants.REGEXP:
-            node.addValue(new Integer(TokenPattern.REGEXP_TYPE));
+            node.addValue(Integer.valueOf(TokenPattern.REGEXP_TYPE));
             break;
         }
         node.addValue(getStringValue(getChildAt(node, 0), 0));

--- a/src/java/net/percederberg/grammatica/Grammar.java
+++ b/src/java/net/percederberg/grammatica/Grammar.java
@@ -352,7 +352,7 @@ public class Grammar extends Object {
      * @return the token pattern, or null
      */
     public TokenPattern getTokenPatternById(int id) {
-        return (TokenPattern) tokenIds.get(new Integer(id));
+        return (TokenPattern) tokenIds.get(Integer.valueOf(id));
     }
 
     /**
@@ -406,7 +406,7 @@ public class Grammar extends Object {
      * @return the production pattern, or null
      */
     public ProductionPattern getProductionPatternById(int id) {
-        return (ProductionPattern) productionIds.get(new Integer(id));
+        return (ProductionPattern) productionIds.get(Integer.valueOf(id));
     }
 
     /**
@@ -439,7 +439,7 @@ public class Grammar extends Object {
      */
     void addToken(TokenPattern token, int start, int end) {
         tokens.add(token);
-        tokenIds.put(new Integer(token.getId()), token);
+        tokenIds.put(Integer.valueOf(token.getId()), token);
         tokenNames.put(token.getName(), token);
         if (token.getType() == TokenPattern.STRING_TYPE) {
             tokenPatterns.put(token.getPattern(), token);
@@ -456,7 +456,7 @@ public class Grammar extends Object {
      */
     void addProduction(ProductionPattern production, int start, int end) {
         productions.add(production);
-        productionIds.put(new Integer(production.getId()), production);
+        productionIds.put(Integer.valueOf(production.getId()), production);
         productionNames.put(production.getName(), production);
         lines.put(production.getName(), new LineRange(start, end));
     }

--- a/src/java/net/percederberg/grammatica/output/CSharpConstantsFile.java
+++ b/src/java/net/percederberg/grammatica/output/CSharpConstantsFile.java
@@ -114,7 +114,7 @@ class CSharpConstantsFile {
 
         constant = gen.getCodeStyle().getUpperCase(pattern.getName());
         enm.addConstant(constant, String.valueOf(pattern.getId()));
-        constantNames.put(new Integer(pattern.getId()), constant);
+        constantNames.put(Integer.valueOf(pattern.getId()), constant);
     }
 
     /**
@@ -129,7 +129,7 @@ class CSharpConstantsFile {
         if (!pattern.isSynthetic()) {
             constant = gen.getCodeStyle().getUpperCase(pattern.getName());
             enm.addConstant(constant, String.valueOf(pattern.getId()));
-            constantNames.put(new Integer(pattern.getId()), constant);
+            constantNames.put(Integer.valueOf(pattern.getId()), constant);
         }
     }
 
@@ -143,7 +143,7 @@ class CSharpConstantsFile {
      *         null if not found
      */
     public String getConstant(int id) {
-        String  name = (String) constantNames.get(new Integer(id));
+        String  name = (String) constantNames.get(Integer.valueOf(id));
 
         if (name == null) {
             return null;

--- a/src/java/net/percederberg/grammatica/output/CSharpParserFile.java
+++ b/src/java/net/percederberg/grammatica/output/CSharpParserFile.java
@@ -238,7 +238,7 @@ class CSharpParserFile {
         if (pattern.isSynthetic()) {
             constant = "SUBPRODUCTION_" + constantId;
             enm.addConstant(constant, String.valueOf(constantId + 3000));
-            constantNames.put(new Integer(pattern.getId()), constant);
+            constantNames.put(Integer.valueOf(pattern.getId()), constant);
             constantId++;
         }
     }
@@ -261,7 +261,7 @@ class CSharpParserFile {
         code.append(",\n");
         code.append("                                \"");
         if (pattern.isSynthetic()) {
-            str = (String) constantNames.get(new Integer(pattern.getId()));
+            str = (String) constantNames.get(Integer.valueOf(pattern.getId()));
             code.append(gen.getCodeStyle().getMixedCase(str, true));
         } else {
             code.append(pattern.getName());
@@ -333,7 +333,7 @@ class CSharpParserFile {
      * @return the constant name to use
      */
     private String getConstant(CSharpConstantsFile constants, int id) {
-        Integer  value = new Integer(id);
+        Integer  value = Integer.valueOf(id);
 
         if (constantNames.containsKey(value)) {
             return "SynteticPatterns." + constantNames.get(value);

--- a/src/java/net/percederberg/grammatica/output/JavaConstantsFile.java
+++ b/src/java/net/percederberg/grammatica/output/JavaConstantsFile.java
@@ -132,7 +132,7 @@ class JavaConstantsFile {
                                "" + pattern.getId());
         var.addComment(new JavaComment(TOKEN_COMMENT));
         ifc.addVariable(var);
-        constantNames.put(new Integer(pattern.getId()), constant);
+        constantNames.put(Integer.valueOf(pattern.getId()), constant);
     }
 
     /**
@@ -156,7 +156,7 @@ class JavaConstantsFile {
                                    "" + pattern.getId());
             var.addComment(new JavaComment(PRODUCTION_COMMENT));
             ifc.addVariable(var);
-            constantNames.put(new Integer(pattern.getId()), constant);
+            constantNames.put(Integer.valueOf(pattern.getId()), constant);
         }
     }
 
@@ -170,7 +170,7 @@ class JavaConstantsFile {
      *         null if not found
      */
     public String getConstant(int id) {
-        String  name = (String) constantNames.get(new Integer(id));
+        String  name = (String) constantNames.get(Integer.valueOf(id));
 
         if (name == null) {
             return null;

--- a/src/java/net/percederberg/grammatica/output/JavaParserFile.java
+++ b/src/java/net/percederberg/grammatica/output/JavaParserFile.java
@@ -242,7 +242,7 @@ class JavaParserFile {
                                    String.valueOf(constantId + 3000));
             var.addComment(new JavaComment(PRODUCTION_COMMENT));
             cls.addVariable(var);
-            constantNames.put(new Integer(pattern.getId()), constant);
+            constantNames.put(Integer.valueOf(pattern.getId()), constant);
             constantId++;
         }
     }
@@ -336,7 +336,7 @@ class JavaParserFile {
      * @return the constant name to use
      */
     private String getConstant(JavaConstantsFile constants, int id) {
-        Integer  value = new Integer(id);
+        Integer  value = Integer.valueOf(id);
 
         if (constantNames.containsKey(value)) {
             return (String) constantNames.get(value);

--- a/src/java/net/percederberg/grammatica/output/VisualBasicConstantsFile.java
+++ b/src/java/net/percederberg/grammatica/output/VisualBasicConstantsFile.java
@@ -120,7 +120,7 @@ class VisualBasicConstantsFile {
 
         constant = gen.getCodeStyle().getUpperCase(pattern.getName());
         enm.addConstant(constant, String.valueOf(pattern.getId()));
-        constantNames.put(new Integer(pattern.getId()), constant);
+        constantNames.put(Integer.valueOf(pattern.getId()), constant);
     }
 
     /**
@@ -135,7 +135,7 @@ class VisualBasicConstantsFile {
         if (!pattern.isSynthetic()) {
             constant = gen.getCodeStyle().getUpperCase(pattern.getName());
             enm.addConstant(constant, String.valueOf(pattern.getId()));
-            constantNames.put(new Integer(pattern.getId()), constant);
+            constantNames.put(Integer.valueOf(pattern.getId()), constant);
         }
     }
 
@@ -149,7 +149,7 @@ class VisualBasicConstantsFile {
      *         null if not found
      */
     public String getConstant(int id) {
-        String  name = (String) constantNames.get(new Integer(id));
+        String  name = (String) constantNames.get(Integer.valueOf(id));
 
         if (name == null) {
             return null;

--- a/src/java/net/percederberg/grammatica/output/VisualBasicParserFile.java
+++ b/src/java/net/percederberg/grammatica/output/VisualBasicParserFile.java
@@ -244,7 +244,7 @@ class VisualBasicParserFile {
         if (pattern.isSynthetic()) {
             constant = "SUBPRODUCTION_" + constantId;
             enm.addConstant(constant, String.valueOf(constantId + 3000));
-            constantNames.put(new Integer(pattern.getId()), constant);
+            constantNames.put(Integer.valueOf(pattern.getId()), constant);
             constantId++;
         }
     }
@@ -266,7 +266,7 @@ class VisualBasicParserFile {
         code.append(getConstant(constants, pattern.getId()));
         code.append("), \"");
         if (pattern.isSynthetic()) {
-            str = (String) constantNames.get(new Integer(pattern.getId()));
+            str = (String) constantNames.get(Integer.valueOf(pattern.getId()));
             code.append(gen.getCodeStyle().getMixedCase(str, true));
         } else {
             code.append(pattern.getName());
@@ -338,7 +338,7 @@ class VisualBasicParserFile {
      * @return the constant name to use
      */
     private String getConstant(VisualBasicConstantsFile constants, int id) {
-        Integer  value = new Integer(id);
+        Integer  value = Integer.valueOf(id);
 
         if (constantNames.containsKey(value)) {
             return "SynteticPatterns." + constantNames.get(value);

--- a/src/java/net/percederberg/grammatica/parser/LookAheadSet.java
+++ b/src/java/net/percederberg/grammatica/parser/LookAheadSet.java
@@ -605,7 +605,7 @@ class LookAheadSet {
         public Sequence(boolean repeat, int token) {
             this.repeat = false;
             this.tokens = new ArrayList(1);
-            this.tokens.add(new Integer(token));
+            this.tokens.add(Integer.valueOf(token));
         }
 
         /**

--- a/src/java/net/percederberg/grammatica/parser/Parser.java
+++ b/src/java/net/percederberg/grammatica/parser/Parser.java
@@ -206,7 +206,7 @@ public abstract class Parser {
     public void addPattern(ProductionPattern pattern)
         throws ParserCreationException {
 
-        Integer  id = new Integer(pattern.getId());
+        Integer  id = Integer.valueOf(pattern.getId());
 
         if (pattern.getAlternativeCount() <= 0) {
             throw new ParserCreationException(
@@ -451,7 +451,7 @@ public abstract class Parser {
      *         null if non-existent
      */
     ProductionPattern getPattern(int id) {
-        Integer  value = new Integer(id);
+        Integer  value = Integer.valueOf(id);
 
         return (ProductionPattern) patternIds.get(value);
     }

--- a/src/java/net/percederberg/grammatica/parser/RecursiveDescentParser.java
+++ b/src/java/net/percederberg/grammatica/parser/RecursiveDescentParser.java
@@ -883,7 +883,7 @@ public class RecursiveDescentParser extends Parser {
          *         false otherwise
          */
         public boolean contains(String name, int value) {
-            Integer  obj = new Integer(value);
+            Integer  obj = Integer.valueOf(value);
 
             for (int i = 0; i < nameStack.size(); i++) {
                 if (nameStack.get(i).equals(name)
@@ -912,7 +912,7 @@ public class RecursiveDescentParser extends Parser {
          */
         public void push(String name, int value) {
             nameStack.add(name);
-            valueStack.add(new Integer(value));
+            valueStack.add(Integer.valueOf(value));
         }
 
         /**

--- a/src/java/net/percederberg/grammatica/parser/TokenNFA.java
+++ b/src/java/net/percederberg/grammatica/parser/TokenNFA.java
@@ -655,7 +655,7 @@ class TokenNFA {
             if (ignoreCase) {
                 c = Character.toLowerCase(c);
             }
-            addContent(new Character(c));
+            addContent(Character.valueOf(c));
         }
 
         /**

--- a/src/java/net/percederberg/grammatica/parser/re/CharacterSetElement.java
+++ b/src/java/net/percederberg/grammatica/parser/re/CharacterSetElement.java
@@ -192,7 +192,7 @@ class CharacterSetElement extends Element {
      * @param c              the character to add
      */
     public void addCharacter(char c) {
-        addContent(new Character(c));
+        addContent(Character.valueOf(c));
     }
 
     /**

--- a/test/src/java/net/percederberg/grammatica/test/ArithmeticCalculator.java
+++ b/test/src/java/net/percederberg/grammatica/test/ArithmeticCalculator.java
@@ -127,7 +127,7 @@ class ArithmeticCalculator extends ArithmeticAnalyzer {
      * @return the node to add to the parse tree
      */
     protected Node exitNumber(Token node) {
-        node.addValue(new Integer(node.getImage()));
+        node.addValue(Integer.valueOf(node.getImage()));
         return node;
     }
 
@@ -165,7 +165,7 @@ class ArithmeticCalculator extends ArithmeticAnalyzer {
             op = (String) values.get(1);
             result = operate(op, value1, value2);
         }
-        node.addValue(new Integer(result));
+        node.addValue(Integer.valueOf(result));
         return node;
     }
 
@@ -203,7 +203,7 @@ class ArithmeticCalculator extends ArithmeticAnalyzer {
             op = (String) values.get(1);
             result = operate(op, value1, value2);
         }
-        node.addValue(new Integer(result));
+        node.addValue(Integer.valueOf(result));
         return node;
     }
 
@@ -236,7 +236,7 @@ class ArithmeticCalculator extends ArithmeticAnalyzer {
         } else {
             result = getIntValue(getChildAt(node, 1), 0);
         }
-        node.addValue(new Integer(result));
+        node.addValue(Integer.valueOf(result));
         return node;
     }
 

--- a/test/src/java/net/percederberg/grammatica/test/TestArithmeticCalculator.java
+++ b/test/src/java/net/percederberg/grammatica/test/TestArithmeticCalculator.java
@@ -45,7 +45,7 @@ public class TestArithmeticCalculator extends TestCase {
      */
     public TestArithmeticCalculator(String name) {
         super(name);
-        variables.put("a", new Integer(2));
+        variables.put("a", Integer.valueOf(2));
     }
 
     /**


### PR DESCRIPTION
This PR fixes deprecated constructors for `Integer` and `Character` according to the example from StackOverflow: https://stackoverflow.com/questions/47095474/the-constructors-integerint-doubledouble-longlong-and-so-on-are-deprecat