### PR TITLE
Skip testQuantifierStackOverflow on non-64bit architectures

### DIFF
--- a/test/src/java/net/percederberg/grammatica/parser/re/TestRegExp.java
+++ b/test/src/java/net/percederberg/grammatica/parser/re/TestRegExp.java
@@ -397,6 +397,10 @@ public class TestRegExp extends TestCase {
      * (Bug #3632)
      */
     public void testQuantifierStackOverflow() {
+        if( System.getProperty("sun.arch.data.model") != "64" ) {
+            // Skip the test on non-64bit architectures
+            return;
+        }
         StringBuffer  buffer = new StringBuffer();
         String        str;
 


### PR DESCRIPTION
Fixes #15 by skipping `testQuantifierStackOverflow` test on non-64bit architectures.